### PR TITLE
ESGF auth was failing when username was None

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,8 @@ There are a few steps required to connect to NASA Earthdata:
 Version History
 ---------------
 
+0.2.4:  Bug fix for ESGF.
+
 0.2.3:  New authentication method. Support URS NASA Earthdata
 
 0.2.2:  Pydap 3.1.1 is now a requirement.

--- a/netcdf4_pydap/cas/esgf.py
+++ b/netcdf4_pydap/cas/esgf.py
@@ -28,10 +28,13 @@ def _uri(openid):
     def generate_url(dest_url):
         dest_node = _get_node(dest_url)
 
-        url = (dest_node +
-               '/esg-orp/j_spring_openid_security_check.htm?'
-               'openid_identifier=' +
-               quote_plus(openid))
+        try:
+            url = (dest_node +
+                   '/esg-orp/j_spring_openid_security_check.htm?'
+                   'openid_identifier=' +
+                   quote_plus(openid))
+        except TypeError:
+            raise UserWarning('OPENID was not set. ESGF connection cannot succeed.')
         if _get_node(openid) == 'https://ceda.ac.uk':
             return [url, None]
         else:

--- a/netcdf4_pydap/tests/test_cas.py
+++ b/netcdf4_pydap/tests/test_cas.py
@@ -5,21 +5,17 @@ Test module for CAS
 import os
 import requests
 import netcdf4_pydap
-import pytest
 import numpy as np
-import time
 
-#@pytest.mark.xfail(os.getcwd() == '/home/travis/build/laliberte/netcdf4_pydap',
-#                   reason=('urs.earthdata.nasa.gov does not seem to accept'
-#                           'connections from Travis-CI'))
+
 def test_urs_earthdata_nasa_gov():
     """
     Test the urs.earthdata.nasa.gov portal.
     """
-    cred = {'username' : os.environ['USERNAME_URS'],
-            'password' : os.environ['PASSWORD_URS'],
-            'use_certificates' : False,
-            'authentication_url' : 'https://urs.earthdata.nasa.gov/'}
+    cred = {'username': os.environ.get('USERNAME_URS'),
+            'password': os.environ.get('PASSWORD_URS'),
+            'use_certificates': False,
+            'authentication_url': 'https://urs.earthdata.nasa.gov/'}
     url = ('http://goldsmr3.gesdisc.eosdis.nasa.gov:80/opendap/'
            'MERRA_MONTHLY/MAIMCPASM.5.2.0/1979/'
            'MERRA100.prod.assim.instM_3d_asm_Cp.197901.hdf')
@@ -27,11 +23,16 @@ def test_urs_earthdata_nasa_gov():
     session = requests.Session()
     with netcdf4_pydap.Dataset(url, session=session, **cred) as dataset:
         data = dataset.variables['SLP'][0, :5, :5]
-    expected_data = [[[99066.15625, 99066.15625, 99066.15625, 99066.15625, 99066.15625],
-                      [98868.15625, 98870.15625, 98872.15625, 98874.15625, 98874.15625],
-                      [98798.15625, 98810.15625, 98820.15625, 98832.15625, 98844.15625],
-                      [98856.15625, 98828.15625, 98756.15625, 98710.15625, 98776.15625],
-                      [99070.15625, 99098.15625, 99048.15625, 98984.15625, 99032.15625]]]
+    expected_data = [[[99066.15625, 99066.15625, 99066.15625, 99066.15625,
+                       99066.15625],
+                      [98868.15625, 98870.15625, 98872.15625, 98874.15625,
+                       98874.15625],
+                      [98798.15625, 98810.15625, 98820.15625, 98832.15625,
+                       98844.15625],
+                      [98856.15625, 98828.15625, 98756.15625, 98710.15625,
+                       98776.15625],
+                      [99070.15625, 99098.15625, 99048.15625, 98984.15625,
+                       99032.15625]]]
     assert (data == expected_data).all()
     # Make sure that credentials were propagated in session object:
     assert ('nasa_gesdisc_data_archive' in session.cookies.get_dict())
@@ -43,26 +44,32 @@ def test_esgf():
     """
     import netcdf4_pydap.cas.esgf as esgf
     cred = {'username': None,
-            'password': os.environ['PASSWORD_ESGF'],
+            'password': os.environ.get('PASSWORD_ESGF'),
             'use_certificates': False,
-            'authentication_url': esgf._uri(os.environ['OPENID_ESGF'])}
+            'authentication_url': esgf._uri(os.environ.get('OPENID_ESGF'))}
     url = ('http://cordexesg.dmi.dk/thredds/dodsC/cordex_general/'
            'cordex/output/EUR-11/DMI/ICHEC-EC-EARTH/historical/r3i1p1/'
            'DMI-HIRHAM5/v1/day/pr/v20131119/'
-           'pr_EUR-11_ICHEC-EC-EARTH_historical_r3i1p1_DMI-HIRHAM5_v1_day_19960101-20001231.nc')
+           'pr_EUR-11_ICHEC-EC-EARTH_historical_r3i1p1_DMI-HIRHAM5_v1_day_'
+           '19960101-20001231.nc')
 
     session = requests.Session()
     with netcdf4_pydap.Dataset(url, session=session, **cred) as dataset:
         data = dataset.variables['pr'][0, 200:205, 100:105]
-    expected_data = [[[5.23546005e-05,  5.48864300e-05,  5.23546005e-05,  6.23914966e-05,
+    expected_data = [[[5.23546005e-05, 5.48864300e-05, 5.23546005e-05,
+                       6.23914966e-05,
                        6.26627589e-05],
-                      [5.45247385e-05,  5.67853021e-05,  5.90458621e-05,  6.51041701e-05,
+                      [5.45247385e-05, 5.67853021e-05, 5.90458621e-05,
+                       6.51041701e-05,
                        6.23914966e-05],
-                      [5.57906533e-05,  5.84129048e-05,  6.37478297e-05,  5.99500854e-05,
+                      [5.57906533e-05, 5.84129048e-05, 6.37478297e-05,
+                       5.99500854e-05,
                        5.85033267e-05],
-                      [5.44343166e-05,  5.45247385e-05,  5.60619228e-05,  5.58810752e-05,
+                      [5.44343166e-05, 5.45247385e-05, 5.60619228e-05,
+                       5.58810752e-05,
                        4.91898136e-05],
-                      [5.09982638e-05,  4.77430549e-05,  4.97323490e-05,  5.43438946e-05,
+                      [5.09982638e-05, 4.77430549e-05, 4.97323490e-05,
+                       5.43438946e-05,
                        5.26258664e-05]]]
     assert np.isclose(data, expected_data).all()
     # Make sure that credentials were propagated in session object:
@@ -75,17 +82,16 @@ def test_esgf_print():
     """
     import netcdf4_pydap.cas.esgf as esgf
     cred = {'username': None,
-            'password': os.environ['PASSWORD_ESGF'],
+            'password': os.environ.get('PASSWORD_ESGF'),
             'use_certificates': False,
-            'authentication_url': esgf._uri(os.environ['OPENID_ESGF'])}
+            'authentication_url': esgf._uri(os.environ.get('OPENID_ESGF'))}
     url = ('http://cordexesg.dmi.dk/thredds/dodsC/cordex_general/'
            'cordex/output/EUR-11/DMI/ICHEC-EC-EARTH/historical/r3i1p1/'
            'DMI-HIRHAM5/v1/day/pr/v20131119/'
-           'pr_EUR-11_ICHEC-EC-EARTH_historical_r3i1p1_DMI-HIRHAM5_v1_day_19960101-20001231.nc')
+           'pr_EUR-11_ICHEC-EC-EARTH_historical_r3i1p1_DMI-HIRHAM5_v1_day_'
+           '19960101-20001231.nc')
 
     session = requests.Session()
     with netcdf4_pydap.Dataset(url, session=session, **cred) as dataset:
         data = dataset.variables['pr'][0, 200:205, 100:105]
         print(data)
-
-

--- a/netcdf4_pydap/tests/test_core.py
+++ b/netcdf4_pydap/tests/test_core.py
@@ -5,9 +5,6 @@ Test module for CAS
 import os
 import requests
 import netcdf4_pydap
-import pytest
-import numpy as np
-import time
 
 
 def test_string_var():
@@ -19,13 +16,15 @@ def test_string_var():
             'password': os.environ['PASSWORD_ESGF'],
             'use_certificates': False,
             'authentication_url': esgf._uri(os.environ['OPENID_ESGF'])}
-    url = ('http://esgf-data1.ceda.ac.uk/thredds/dodsC/esg_dataroot/cmip5/output1/'
+    url = ('http://esgf-data1.ceda.ac.uk/thredds/dodsC/'
+           'esg_dataroot/cmip5/output1/'
            'NCC/NorESM1-M/abrupt4xCO2/mon/ocean/Omon/r1i1p1/v20110901/msftmyz/'
            'msftmyz_Omon_NorESM1-M_abrupt4xCO2_r1i1p1_000101-015012.nc')
 
     session = requests.Session()
     with netcdf4_pydap.Dataset(url, session=session, **cred) as dataset:
         assert (dataset.variables['region'].dtype == '|S200')
+
 
 def test_content_description():
     """
@@ -36,7 +35,8 @@ def test_content_description():
             'password': os.environ['PASSWORD_ESGF'],
             'use_certificates': False,
             'authentication_url': esgf._uri(os.environ['OPENID_ESGF'])}
-    url = ('http://noresg.norstore.no/thredds/dodsC/esg_dataroot/cmor/CMIP5/output1/'
+    url = ('http://noresg.norstore.no/thredds/dodsC/'
+           'esg_dataroot/cmor/CMIP5/output1/'
            'NCC/NorESM1-M/abrupt4xCO2/mon/ocean/Omon/r1i1p1/v20110901/msftmyz/'
            'msftmyz_Omon_NorESM1-M_abrupt4xCO2_r1i1p1_000101-015012.nc')
 
@@ -45,8 +45,9 @@ def test_content_description():
     from pydap.exceptions import ServerError
     try:
         with netcdf4_pydap.Dataset(url, session=session, **cred) as dataset:
+            dataset.__repr__()
             pass
     except ServerError:
         pass
     except:
-        raise
+        assert(False)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools import setup, find_packages
 package_name='netcdf4_pydap'
 setup(
        name = package_name,
-       version = "0.2.3",
+       version = "0.2.4",
        packages = find_packages(),
 #
 #        # metadata for upload to PyPI


### PR DESCRIPTION
This PR solves a bug introduced in the previous version whereas a None username was throwing an exception.